### PR TITLE
Fix rt#78959 by using default optimize flag

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,7 +54,6 @@ if (-d "/usr/include/openssl") {
 }
 
 cc_lib_links('crypto');
-cc_optimize_flags('-O3 -Wall -Werror');
 
 requires 'Crypt::OpenSSL::X509';
 


### PR DESCRIPTION
See https://rt.cpan.org/Public/Bug/Display.html?id=78959

If we do not explicitly set the cc_optimize_flag here, it would use the default optimize flag in %Config. 